### PR TITLE
Add entities to world + basic desires for #27

### DIFF
--- a/remoteentities.iml
+++ b/remoteentities.iml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/target" />
+    <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
-    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" isTestSource="false" />
@@ -11,6 +10,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="bukkit-dev" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.bukkit:craftbukkit:1.4.7-R0.1" level="project" />
   </component>
 </module>

--- a/remoteentities.iml
+++ b/remoteentities.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.bukkit:craftbukkit:1.4.7-R0.1" level="project" />
+  </component>
+</module>
+

--- a/src/main/java/de/kumpelblase2/remoteentities/ChunkEntityLoader.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/ChunkEntityLoader.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_4_R1.CraftWorld;
@@ -26,29 +28,25 @@ class ChunkEntityLoader implements Listener
 	{
 		this.m_manager = inManager;
 		this.m_toSpawn = new HashMap<RemoteEntity, Location>();
+
+        this.populateSpawns();
 	}
 	
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onChunkLoad(ChunkLoadEvent event)
 	{
 		Chunk c = event.getChunk();
-		for(RemoteEntity entity : this.m_manager.getAllEntities())
-		{
-			if(!entity.isSpawned())
-				continue;
-			
-			if(entity.getBukkitEntity().getLocation().getChunk() == c && entity.getHandle() != null)
-				((CraftWorld)c.getWorld()).getHandle().addEntity(entity.getHandle());				
-		}
-		
+
+        this.populateSpawns();
+
 		Iterator<Entry<RemoteEntity, Location>> it = this.m_toSpawn.entrySet().iterator();
-		while(it.hasNext())
-		{
+
+		while (it.hasNext()) {
 			Entry<RemoteEntity, Location> toSpawn = it.next();
+
 			Location loc = toSpawn.getValue();
-			if(loc.getChunk() == c)
-			{
-				toSpawn.getKey().spawn(loc);
+			if (c == loc.getChunk()) {
+                toSpawn.getKey().spawn(loc);
 				it.remove();
 			}
 		}
@@ -74,4 +72,16 @@ class ChunkEntityLoader implements Listener
 			}
 		}
 	}
+
+    public void populateSpawns()
+    {
+        for(RemoteEntity entity : this.m_manager.getAllEntities())
+        {
+            if(!entity.isSpawned())
+                continue;
+
+
+            this.m_toSpawn.put(entity, entity.getBukkitEntity().getLocation());
+        }
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/ChunkEntityLoader.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/ChunkEntityLoader.java
@@ -1,14 +1,10 @@
 package de.kumpelblase2.remoteentities;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
-
+import de.kumpelblase2.remoteentities.api.DespawnReason;
+import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_4_R1.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventHandler;
@@ -16,72 +12,99 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
-import de.kumpelblase2.remoteentities.api.DespawnReason;
-import de.kumpelblase2.remoteentities.api.RemoteEntity;
 
-class ChunkEntityLoader implements Listener
-{
-	private EntityManager m_manager;
-	private Map<RemoteEntity, Location> m_toSpawn;
-	
-	ChunkEntityLoader(EntityManager inManager)
-	{
-		this.m_manager = inManager;
-		this.m_toSpawn = new HashMap<RemoteEntity, Location>();
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.Map.Entry;
 
-        this.populateSpawns();
-	}
-	
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void onChunkLoad(ChunkLoadEvent event)
-	{
-		Chunk c = event.getChunk();
+class ChunkEntityLoader implements Listener {
+    private EntityManager m_manager;
+    public Hashtable<RemoteEntity, Location> toSpawn;
+
+    ChunkEntityLoader(EntityManager inManager) {
+        this.m_manager = inManager;
+        this.toSpawn = new Hashtable<RemoteEntity, Location>();
 
         this.populateSpawns();
+    }
 
-		Iterator<Entry<RemoteEntity, Location>> it = this.m_toSpawn.entrySet().iterator();
 
-		while (it.hasNext()) {
-			Entry<RemoteEntity, Location> toSpawn = it.next();
+    class DelayedChunkLoadHandler implements Runnable {
+        private ChunkEntityLoader loader;
+        private ChunkLoadEvent event;
 
-			Location loc = toSpawn.getValue();
-			if (c == loc.getChunk()) {
-                toSpawn.getKey().spawn(loc);
-				it.remove();
-			}
-		}
-	}
-	
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void onChunkUnload(ChunkUnloadEvent event)
-	{
-		Chunk c = event.getChunk();
-		for(Entity entity : c.getEntities())
-		{
-			if(!(entity instanceof LivingEntity))
-				continue;
-			
-			if(RemoteEntities.isRemoteEntity((LivingEntity)entity))
-			{
-				RemoteEntity rentity = (RemoteEntity)RemoteEntities.getRemoteEntityFromEntity((LivingEntity)entity);
-				if(rentity.isSpawned())
-				{
-					this.m_toSpawn.put(rentity, rentity.getBukkitEntity().getLocation());
-					rentity.despawn(DespawnReason.CHUNK_UNLOAD);
-				}
-			}
-		}
-	}
+        DelayedChunkLoadHandler(ChunkEntityLoader loader, ChunkLoadEvent event) {
+            this.loader = loader;
+            this.event = event;
+        }
 
-    public void populateSpawns()
-    {
-        for(RemoteEntity entity : this.m_manager.getAllEntities())
-        {
-            if(!entity.isSpawned())
+        @Override
+        public void run() {
+            Chunk c = this.event.getChunk();
+
+            Iterator entryIterator = this.loader.toSpawn.entrySet().iterator();
+
+            while (entryIterator.hasNext()) {
+                Entry<RemoteEntity, Location> toSpawn = (Entry<RemoteEntity, Location>) entryIterator.next();
+                Location loc = toSpawn.getValue();
+                if (c == loc.getChunk()) {
+                    RemoteEntity keyEntity = toSpawn.getKey();
+                    keyEntity.spawn(loc);
+                    entryIterator.remove();
+                }
+            }
+        }
+    }
+
+    class DelayedChunkUnloadHandler implements Runnable {
+        private ChunkEntityLoader loader;
+        private Chunk chunk;
+        private EntityManager manager;
+        private Entity[] entitySnapshot;
+
+        DelayedChunkUnloadHandler(ChunkEntityLoader loader, Chunk chunk, Entity[] entitySnapshot, EntityManager manager) {
+            this.loader = loader;
+            this.chunk = chunk;
+            this.manager = manager;
+            this.entitySnapshot = entitySnapshot;
+        }
+
+        @Override
+        public void run() {
+
+            for (Entity entity : this.entitySnapshot) {
+                if (!(entity instanceof LivingEntity))
+                    continue;
+
+
+                if (RemoteEntities.isRemoteEntity((LivingEntity) entity)) {
+                    RemoteEntity rentity = (RemoteEntity) RemoteEntities.getRemoteEntityFromEntity((LivingEntity) entity);
+                    if (rentity.isSpawned()) {
+                        this.loader.toSpawn.put(rentity, rentity.getBukkitEntity().getLocation());
+                        rentity.despawn(DespawnReason.CHUNK_UNLOAD);
+                    }
+                }
+            }
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onChunkLoad(ChunkLoadEvent event) {
+        Bukkit.getScheduler().runTask(this.m_manager.getPlugin(), new DelayedChunkLoadHandler(this, event));
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onChunkUnload(ChunkUnloadEvent event) {
+        Bukkit.getScheduler().runTask(this.m_manager.getPlugin(), new DelayedChunkUnloadHandler(this, event.getChunk(), event.getChunk().getEntities(), this.m_manager));
+    }
+
+    public void populateSpawns() {
+        for (RemoteEntity entity : this.m_manager.getAllEntities()) {
+            if (!entity.isSpawned() || this.toSpawn.containsKey(entity))
                 continue;
 
 
-            this.m_toSpawn.put(entity, entity.getBukkitEntity().getLocation());
+            this.toSpawn.put(entity, entity.getBukkitEntity().getLocation());
         }
     }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/CreateEntityContext.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/CreateEntityContext.java
@@ -3,6 +3,8 @@ package de.kumpelblase2.remoteentities;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import net.minecraft.server.v1_4_R1.Chunk;
 import org.bukkit.Location;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.api.RemoteEntityType;
@@ -238,9 +240,19 @@ public class CreateEntityContext
 		
 		if(this.m_maxHealth != -1)
 			created.getBukkitEntity().setMaxHealth(this.m_maxHealth);
-		
-		if(this.m_location != null)
-			created.spawn(this.m_location);
+
+        boolean isLoaded = false;
+
+        for (org.bukkit.Chunk chunk : this.m_location.getWorld().getLoadedChunks()) {
+            if (chunk == this.m_location.getChunk())
+                isLoaded = true;
+        }
+
+		if(this.m_location != null && isLoaded) {
+            created.spawn(this.m_location);
+            System.out.println("SPAWNED");
+        }
+
 		
 		return created;
 	}

--- a/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
@@ -4,6 +4,9 @@ import java.lang.reflect.Constructor;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
+
+import de.kumpelblase2.remoteentities.api.thinking.Desire;
+import de.kumpelblase2.remoteentities.persistence.DesireData;
 import net.minecraft.server.v1_4_R1.EntityLiving;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -406,7 +409,15 @@ public class EntityManager
 			return;
 		
 		EntityData[] data = this.m_serializer.loadData();
-		for(EntityData entity : data)
-		    this.m_serializer.create(entity);
+		for (EntityData entityData : data) {
+            RemoteEntity entity = this.m_serializer.create(entityData);
+            for (DesireData desireData : entityData.desires) {
+                Desire desire = this.m_serializer.create(desireData);
+//                System.out.println(desire);
+                entity.getMind().addMovementDesire(desire, desireData.priority);
+            }
+        }
+
+
 	}
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
@@ -407,6 +407,6 @@ public class EntityManager
 		
 		EntityData[] data = this.m_serializer.loadData();
 		for(EntityData entity : data)
-			this.m_serializer.create(entity);
+			this.addRemoteEntity(0, this.m_serializer.create(entity));
 	}
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
@@ -34,7 +34,6 @@ public class EntityManager
 		this.m_entities = new ConcurrentHashMap<Integer, RemoteEntity>();
 		this.m_removeDespawned = inRemoveDespawed;
 		this.m_entityChunkLoader = new ChunkEntityLoader(this);
-		Bukkit.getPluginManager().registerEvents(this.m_entityChunkLoader, RemoteEntities.getInstance());
 		Bukkit.getScheduler().scheduleSyncRepeatingTask(inPlugin, new Runnable()
 		{
 			@Override
@@ -418,6 +417,6 @@ public class EntityManager
             }
         }
 
-
+             this.m_entityChunkLoader.populateSpawns();
 	}
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
@@ -407,6 +407,6 @@ public class EntityManager
 		
 		EntityData[] data = this.m_serializer.loadData();
 		for(EntityData entity : data)
-			this.addRemoteEntity(0, this.m_serializer.create(entity));
+		    this.m_serializer.create(entity);
 	}
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
@@ -412,7 +412,7 @@ public class EntityManager
 		for (EntityData entityData : data) {
             RemoteEntity entity = this.m_serializer.create(entityData);
             for (DesireData desireData : entityData.desires) {
-                Desire desire = this.m_serializer.create(desireData);
+                Desire desire = this.m_serializer.createDesireForEntity(desireData, entity);
 //                System.out.println(desire);
                 entity.getMind().addMovementDesire(desire, desireData.priority);
             }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/BaseBehavior.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/BaseBehavior.java
@@ -1,6 +1,7 @@
 package de.kumpelblase2.remoteentities.api.thinking;
 
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
+import org.bukkit.plugin.Plugin;
 
 public abstract class BaseBehavior implements Behavior
 {
@@ -12,8 +13,13 @@ public abstract class BaseBehavior implements Behavior
 		this.m_name = inName;
 		this.m_entity = inEntity;
 	}
-	
-	@Override
+
+//    public BaseBehavior(RemoteEntity entity, Plugin plugin)
+//    {
+//
+//    }
+
+    @Override
 	public void run()
 	{
 	}

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Behavior.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Behavior.java
@@ -35,4 +35,6 @@ public interface Behavior extends Listener, Runnable
      * @return Array of strings to be used as basis for deserialized constructors.
      */
     public Object[] getConstructionals();
+
+    public void onEntityUpdate();
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Behavior.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Behavior.java
@@ -28,4 +28,11 @@ public interface Behavior extends Listener, Runnable
 	 * @return entity
 	 */
 	public RemoteEntity getRemoteEntity();
+
+    /**
+     * Returns private data used for persistence re-instantiation
+     *
+     * @return Array of strings to be used as basis for deserialized constructors.
+     */
+    public Object[] getConstructionals();
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Desire.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Desire.java
@@ -70,5 +70,5 @@ public interface Desire
      *
      * @return Array of strings to be used as basis for deserialized constructors.
      */
-    public String[] getConstructionData();
+    public Object[] getConstructionals();
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Desire.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Desire.java
@@ -2,6 +2,8 @@ package de.kumpelblase2.remoteentities.api.thinking;
 
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 
+import java.util.ArrayList;
+
 public interface Desire
 {
 	/**
@@ -62,4 +64,11 @@ public interface Desire
 	 * @return true if it can continue, false if not
 	 */
 	public boolean canContinue();
+
+    /**
+     * Returns private data used for persistence re-instantiation
+     *
+     * @return Array of strings to be used as basis for deserialized constructors.
+     */
+    public String[] getConstructionData();
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/DesireBase.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/DesireBase.java
@@ -77,4 +77,10 @@ public abstract class DesireBase implements Desire
 		else
 			this.getEntityHandle().getNavigation().a(inPath, inSpeed);
 	}
+
+    @Override
+    public Object[] getConstructionals()
+    {
+        return null;
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/DesireBase.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/DesireBase.java
@@ -5,6 +5,8 @@ import net.minecraft.server.v1_4_R1.PathEntity;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.entities.RemoteBaseEntity;
 
+import java.util.ArrayList;
+
 public abstract class DesireBase implements Desire
 {
 	protected final RemoteEntity m_entity;

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Mind.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/Mind.java
@@ -2,6 +2,7 @@ package de.kumpelblase2.remoteentities.api.thinking;
 
 import java.util.*;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
+import org.bukkit.Bukkit;
 
 public class Mind
 {

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookAtNearest.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookAtNearest.java
@@ -2,6 +2,7 @@ package de.kumpelblase2.remoteentities.api.thinking.goals;
 
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.api.thinking.DesireBase;
+import de.kumpelblase2.remoteentities.persistence.ParameterData;
 import net.minecraft.server.v1_4_R1.*;
 
 public class DesireLookAtNearest extends DesireBase
@@ -27,7 +28,13 @@ public class DesireLookAtNearest extends DesireBase
 		this.m_lookPossibility = inPossibility;
 	}
 
-	@Override
+    public DesireLookAtNearest(ParameterData[] parameters)
+    {
+        this(((RemoteEntity)parameters[0].value), (Class<? extends EntityLiving>)parameters[1].value, (Float)parameters[2].value, (Float)parameters[3].value);
+    }
+
+
+    @Override
 	public void startExecuting()
 	{
 		this.m_lookTicks = 40 + this.getEntityHandle().aB().nextInt(40);
@@ -78,7 +85,13 @@ public class DesireLookAtNearest extends DesireBase
     {
         Object[] constructionals = new Object[4];
         constructionals[0] = this.getRemoteEntity();
-        constructionals[1] = this.m_toLookAt;
+
+        Class<? extends EntityLiving> target = EntityLiving.class;
+        Class[] lookAt = new Class[2];
+        lookAt[0] = this.m_toLookAt;
+        lookAt[1] = target;
+
+        constructionals[1] = lookAt;
         constructionals[2] = this.m_minDist;
         constructionals[3] = this.m_lookPossibility;
 

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookAtNearest.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookAtNearest.java
@@ -4,6 +4,8 @@ import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.api.thinking.DesireBase;
 import net.minecraft.server.v1_4_R1.*;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 public class DesireLookAtNearest extends DesireBase
 {
 	protected EntityLiving m_target;
@@ -72,4 +74,23 @@ public class DesireLookAtNearest extends DesireBase
 	{
 		return !this.m_target.isAlive() ? false : (this.getEntityHandle().e(this.m_target) > this.m_minDistSquared ? false : this.m_lookTicks > 0);
 	}
+
+    @Override
+    public Object[] getConstructionals()
+    {
+       Object[] constructionals = new Object[4];
+        constructionals[0] = this.getRemoteEntity();
+
+        Object[] classArray = new Object[2];
+        classArray[0] = this.m_toLookAt;
+
+//        Class extension = ? extends EntityLiving;
+//        classArray[1] = extension;
+
+        constructionals[1] = classArray;
+        constructionals[2] = this.m_minDist;
+        constructionals[3] = this.m_lookPossibility;
+
+        return constructionals;
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookAtNearest.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookAtNearest.java
@@ -4,8 +4,6 @@ import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.api.thinking.DesireBase;
 import net.minecraft.server.v1_4_R1.*;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 public class DesireLookAtNearest extends DesireBase
 {
 	protected EntityLiving m_target;
@@ -78,16 +76,9 @@ public class DesireLookAtNearest extends DesireBase
     @Override
     public Object[] getConstructionals()
     {
-       Object[] constructionals = new Object[4];
+        Object[] constructionals = new Object[4];
         constructionals[0] = this.getRemoteEntity();
-
-        Object[] classArray = new Object[2];
-        classArray[0] = this.m_toLookAt;
-
-//        Class extension = ? extends EntityLiving;
-//        classArray[1] = extension;
-
-        constructionals[1] = classArray;
+        constructionals[1] = this.m_toLookAt;
         constructionals[2] = this.m_minDist;
         constructionals[3] = this.m_lookPossibility;
 

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookRandomly.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookRandomly.java
@@ -54,11 +54,11 @@ public class DesireLookRandomly extends DesireBase
 	}
 
     @Override
-    public String[] getConstructionData()
+    public Object[] getConstructionals()
     {
-        String[] constructionData = new String[1];
-        constructionData[0] = "EntityID = " + this.getRemoteEntity().getID();
+        Object[] constructionals = new Object[1];
+        constructionals[0] = this.getRemoteEntity();
 
-        return constructionData;
+        return constructionals;
     }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookRandomly.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookRandomly.java
@@ -1,5 +1,6 @@
 package de.kumpelblase2.remoteentities.api.thinking.goals;
 
+import de.kumpelblase2.remoteentities.persistence.ParameterData;
 import net.minecraft.server.v1_4_R1.EntityLiving;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.api.thinking.DesireBase;
@@ -19,7 +20,12 @@ public class DesireLookRandomly extends DesireBase
 		this.m_type = 3;
 	}
 
-	@Override
+    public DesireLookRandomly(ParameterData[] parameters)
+    {
+        this(((RemoteEntity)parameters[0].value));
+    }
+
+    @Override
 	public boolean shouldExecute()
 	{
 		if(this.getEntityHandle() == null)

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookRandomly.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireLookRandomly.java
@@ -3,6 +3,9 @@ package de.kumpelblase2.remoteentities.api.thinking.goals;
 import net.minecraft.server.v1_4_R1.EntityLiving;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.api.thinking.DesireBase;
+import org.bukkit.ChatColor;
+
+import java.util.ArrayList;
 
 public class DesireLookRandomly extends DesireBase
 {
@@ -49,4 +52,13 @@ public class DesireLookRandomly extends DesireBase
 		entity.getControllerLook().a(entity.locX + this.m_xDiff, entity.locY + entity.getHeadHeight(), entity.locZ + this.m_zDiff, 10, entity.bp());
 		return true;
 	}
+
+    @Override
+    public String[] getConstructionData()
+    {
+        String[] constructionData = new String[1];
+        constructionData[0] = "EntityID = " + this.getRemoteEntity().getID();
+
+        return constructionData;
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
@@ -28,11 +28,11 @@ public class DesireSwim extends DesireBase
 	}
 
     @Override
-    public String[] getConstructionData()
+    public Object[] getConstructionals()
     {
-        String[] constructionData = new String[1];
-        constructionData[0] = "EntityID = " + this.getRemoteEntity().getID();
+        Object[] constructionals = new Object[1];
+        constructionals[0] = this.getRemoteEntity();
 
-        return constructionData;
+        return constructionals;
     }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
@@ -10,7 +10,9 @@ public class DesireSwim extends DesireBase
 	{
 		super(inEntity);
 		this.m_type = 4;
-		this.getEntityHandle().getNavigation().e(true);
+
+
+
 	}
 
     public DesireSwim(ParameterData[] parameters)
@@ -27,6 +29,11 @@ public class DesireSwim extends DesireBase
     @Override
 	public boolean update()
 	{
+        if (this.getEntityHandle() == null)
+            return false;
+
+        this.getEntityHandle().getNavigation().e(true);
+
 		if(this.getEntityHandle().aB().nextFloat() < 0.8F)
 			this.getEntityHandle().getControllerJump().a();
 		

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
@@ -2,6 +2,7 @@ package de.kumpelblase2.remoteentities.api.thinking.goals;
 
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import de.kumpelblase2.remoteentities.api.thinking.DesireBase;
+import de.kumpelblase2.remoteentities.persistence.ParameterData;
 
 public class DesireSwim extends DesireBase
 {
@@ -11,6 +12,11 @@ public class DesireSwim extends DesireBase
 		this.m_type = 4;
 		this.getEntityHandle().getNavigation().e(true);
 	}
+
+    public DesireSwim(ParameterData[] parameters)
+    {
+        this(((RemoteEntity)parameters[0].value));
+    }
 
 	@Override
 	public boolean shouldExecute()

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
@@ -17,8 +17,8 @@ public class DesireSwim extends DesireBase
 	{
 		return this.getEntityHandle() != null && (this.getEntityHandle().H() || this.getEntityHandle().J());
 	}
-	
-	@Override
+
+    @Override
 	public boolean update()
 	{
 		if(this.getEntityHandle().aB().nextFloat() < 0.8F)
@@ -26,4 +26,13 @@ public class DesireSwim extends DesireBase
 		
 		return true;
 	}
+
+    @Override
+    public String[] getConstructionData()
+    {
+        String[] constructionData = new String[1];
+        constructionData[0] = "EntityID = " + this.getRemoteEntity().getID();
+
+        return constructionData;
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemoteBaseEntity.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemoteBaseEntity.java
@@ -2,6 +2,7 @@ package de.kumpelblase2.remoteentities.entities;
 
 import java.lang.reflect.Field;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_4_R1.CraftWorld;

--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemoteBaseEntity.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemoteBaseEntity.java
@@ -257,14 +257,14 @@ public abstract class RemoteBaseEntity implements RemoteEntity
 	{
 		if(this.isSpawned())
 			return;
-		
+
 		RemoteEntitySpawnEvent event = new RemoteEntitySpawnEvent(this, inLocation);
 		Bukkit.getPluginManager().callEvent(event);
 		if(event.isCancelled())
 			return;
 		
 		inLocation = event.getSpawnLocation();
-		
+
 		try
 		{
 			EntityTypesEntry entry = EntityTypesEntry.fromEntity(this.getNativeEntityName());
@@ -274,6 +274,10 @@ public abstract class RemoteBaseEntity implements RemoteEntity
 			this.m_entity.setPositionRotation(inLocation.getX(), inLocation.getY(), inLocation.getZ(), inLocation.getYaw(), inLocation.getPitch());
 			worldServer.addEntity(this.m_entity, SpawnReason.CUSTOM);
 			entry.restore();
+
+            for (Behavior behavior : this.getMind().getBehaviours()) {
+                behavior.onEntityUpdate();
+            }
 		}
 		catch(Exception e)
 		{
@@ -304,16 +308,12 @@ public abstract class RemoteBaseEntity implements RemoteEntity
 		Bukkit.getPluginManager().callEvent(event);
 		if(event.isCancelled() && inReason != DespawnReason.PLUGIN_DISABLE)
 			return false;
-		
-		for(Behavior behaviour : this.getMind().getBehaviours())
-		{
-			behaviour.onRemove();
-		}
-		
-		this.getMind().clearBehaviours();
+
 		if(this.getBukkitEntity() != null)
 			this.getBukkitEntity().remove();
-		this.m_entity = null;
+
+        this.m_entity = null;
+
 		return true;
 	}
 	

--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
@@ -1,5 +1,6 @@
 package de.kumpelblase2.remoteentities.entities;
 
+import de.kumpelblase2.remoteentities.api.thinking.Behavior;
 import net.minecraft.server.v1_4_R1.EntityHuman;
 import net.minecraft.server.v1_4_R1.EntityLiving;
 import net.minecraft.server.v1_4_R1.EnumBedResult;
@@ -81,7 +82,11 @@ public class RemotePlayer extends RemoteBaseEntity implements Nameable, Fightabl
 		worldServer.addEntity(m_entity);
 		this.m_entity.getBukkitEntity().teleport(inLocation);
 		this.m_entity.world.players.remove(this.m_entity);
-	}
+
+        for (Behavior behavior : this.getMind().getBehaviours()) {
+            behavior.onEntityUpdate();
+        }
+    }
 
 	@Override
 	public LivingEntity getTarget()

--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
@@ -18,6 +18,8 @@ import de.kumpelblase2.remoteentities.api.events.RemoteEntitySpawnEvent;
 public class RemotePlayer extends RemoteBaseEntity implements Nameable, Fightable
 {
 	protected String m_name;
+    public Location intendedLocation;
+
 	
 	public RemotePlayer(int inID, String inName, EntityManager inManager)
 	{

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/BehaviorData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/BehaviorData.java
@@ -1,5 +1,47 @@
 package de.kumpelblase2.remoteentities.persistence;
 
-public class BehaviorData
+import de.kumpelblase2.remoteentities.api.thinking.Behavior;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class BehaviorData implements ConfigurationSerializable
 {
+    public String canonicallyWrittenClass;
+
+    public BehaviorData()
+    {
+
+    }
+
+    public BehaviorData(Behavior behavior)
+    {
+        this.canonicallyWrittenClass = behavior.getClass().getCanonicalName();
+    }
+
+    public BehaviorData(Map<String, Object> inData)
+    {
+        this.canonicallyWrittenClass = (String)inData.get("canonicallyWrittenClass");
+    }
+
+    public Behavior getConstructedClass()
+    {
+        try {
+            return (Behavior)Class.forName(this.canonicallyWrittenClass).newInstance();
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            return null;
+        }
+    }
+
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<String, Object>();
+
+        data.put("canonicallyWrittenClass", this.canonicallyWrittenClass);
+
+        return data;
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/BehaviorData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/BehaviorData.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public class BehaviorData implements ConfigurationSerializable
 {
     public String canonicallyWrittenClass;
+    public ParameterData[] parameterData;
 
     public BehaviorData()
     {
@@ -18,6 +19,7 @@ public class BehaviorData implements ConfigurationSerializable
     public BehaviorData(Behavior behavior)
     {
         this.canonicallyWrittenClass = behavior.getClass().getCanonicalName();
+        this.parameterData = ConstructorSerializer.serializedConstructor(behavior.getConstructionals());
     }
 
     public BehaviorData(Map<String, Object> inData)
@@ -41,6 +43,16 @@ public class BehaviorData implements ConfigurationSerializable
         Map<String, Object> data = new HashMap<String, Object>();
 
         data.put("canonicallyWrittenClass", this.canonicallyWrittenClass);
+
+        Map<String, Object>[] serializedParameters = new HashMap[this.parameterData.length];
+
+        int index = 0;
+        for (ParameterData pData : this.parameterData) {
+            serializedParameters[index] = pData.serialize();
+            index++;
+        }
+
+        data.put("parameters", serializedParameters);
 
         return data;
     }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/ConstructorSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/ConstructorSerializer.java
@@ -1,0 +1,38 @@
+package de.kumpelblase2.remoteentities.persistence;
+
+import de.kumpelblase2.remoteentities.api.RemoteEntity;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConstructorSerializer {
+    public static ParameterData[] serializedConstructor(Object[] constructionals)
+    {
+        ParameterData[] data = new ParameterData[constructionals.length];
+        int index = 0;
+
+        for (Object object : constructionals) {
+            data[index] = new ParameterData(object);
+
+            index++;
+        }
+
+        return data;
+    }
+
+    public static ParameterData[] constructionalsFromArrayForEntity(ParameterData[] parameterData, RemoteEntity entity)
+    {
+        ParameterData[] data = new ParameterData[parameterData.length];
+
+        int index = 0;
+        for (ParameterData paramData : parameterData) {
+            data[index] = paramData.getSynthesizedParameterDataForEntity(entity);
+
+            index++;
+        }
+
+        return data;
+    }
+}

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
@@ -3,6 +3,7 @@ package de.kumpelblase2.remoteentities.persistence;
 import de.kumpelblase2.remoteentities.api.thinking.Desire;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,13 +11,16 @@ public class DesireData implements ConfigurationSerializable
 {
     public String name;
     public int priority;
+    public String[] constructionData;
 
     public DesireData() {
 
     }
 
-    public DesireData(Desire desire) {
-        this.name = desire.getClass().getSimpleName();
+    public DesireData(Desire desire)
+    {
+        this.name = desire.getClass().getCanonicalName();
+        this.constructionData = desire.getConstructionData();
     }
 
     @Override
@@ -26,6 +30,17 @@ public class DesireData implements ConfigurationSerializable
         data.put("name", this.name);
         data.put("priority", this.priority);
 
+        if (this.constructionData != null)
+            data.put("constructionData", this.constructionData);
+
         return data;
+    }
+
+    @SuppressWarnings("unchecked")
+    public DesireData(Map<String, Object> inData)
+    {
+        this.name = (String)inData.get("name");
+        this.priority = ((Integer)inData.get("priority")).intValue();
+        this.constructionData = (String[])inData.get("constructionData");
     }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
@@ -3,7 +3,6 @@ package de.kumpelblase2.remoteentities.persistence;
 import de.kumpelblase2.remoteentities.api.thinking.Desire;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,7 +10,7 @@ public class DesireData implements ConfigurationSerializable
 {
     public String name;
     public int priority;
-    public String[] constructionData;
+    public ParameterData[] constructionData;
 
     public DesireData() {
 
@@ -20,7 +19,7 @@ public class DesireData implements ConfigurationSerializable
     public DesireData(Desire desire)
     {
         this.name = desire.getClass().getCanonicalName();
-        this.constructionData = desire.getConstructionData();
+        this.constructionData = ConstructorSerializer.serializedConstructor(desire.getConstructionals());
     }
 
     @Override
@@ -41,6 +40,6 @@ public class DesireData implements ConfigurationSerializable
     {
         this.name = (String)inData.get("name");
         this.priority = ((Integer)inData.get("priority")).intValue();
-        this.constructionData = (String[])inData.get("constructionData");
+        this.constructionData = (ParameterData[])inData.get("constructionData");
     }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
@@ -17,7 +17,7 @@ public class DesireData implements ConfigurationSerializable
     }
 
     public DesireData(Desire desire) {
-        this.desireName = desire.getClass().toString();
+        this.desireName = desire.getClass().getSimpleName();
         this.type = desire.getType();
     }
 

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
@@ -8,26 +8,23 @@ import java.util.Map;
 
 public class DesireData implements ConfigurationSerializable
 {
-    public String desireName;
+    public String name;
     public int priority;
-    public int type;
 
     public DesireData() {
 
     }
 
     public DesireData(Desire desire) {
-        this.desireName = desire.getClass().getSimpleName();
-        this.type = desire.getType();
+        this.name = desire.getClass().getSimpleName();
     }
 
     @Override
     public Map<String, Object> serialize()
     {
         Map<String, Object> data = new HashMap<String, Object>();
-        data.put("desireName", this.desireName);
+        data.put("name", this.name);
         data.put("priority", this.priority);
-        data.put("type", this.type);
 
         return data;
     }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/DesireData.java
@@ -1,5 +1,34 @@
 package de.kumpelblase2.remoteentities.persistence;
 
-public class DesireData
+import de.kumpelblase2.remoteentities.api.thinking.Desire;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DesireData implements ConfigurationSerializable
 {
+    public String desireName;
+    public int priority;
+    public int type;
+
+    public DesireData() {
+
+    }
+
+    public DesireData(Desire desire) {
+        this.desireName = desire.getClass().toString();
+        this.type = desire.getType();
+    }
+
+    @Override
+    public Map<String, Object> serialize()
+    {
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("desireName", this.desireName);
+        data.put("priority", this.priority);
+        data.put("type", this.type);
+
+        return data;
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
@@ -67,7 +67,6 @@ public class EntityData implements ConfigurationSerializable
 
         for (Behavior behavior : inEntity.getMind().getBehaviours()) {
             this.behaviors[index] = new BehaviorData(behavior);
-            System.out.println(this.behaviors[index]);
             index++;
         }
 	}

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
@@ -26,6 +26,7 @@ public class EntityData implements ConfigurationSerializable
 	
 	public EntityData()
 	{
+
 	}
 	
 	public EntityData(RemoteEntity inEntity)
@@ -73,6 +74,7 @@ public class EntityData implements ConfigurationSerializable
 		this.stationary = (Boolean)inData.get("stationary");
 		this.pushable = (Boolean)inData.get("pushable");
 		this.speed = ((Double)inData.get("speed")).floatValue();
+
         //TODO: behaviors and desires
 	}
 

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import de.kumpelblase2.remoteentities.api.thinking.Behavior;
 import de.kumpelblase2.remoteentities.api.thinking.Desire;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
@@ -61,7 +62,14 @@ public class EntityData implements ConfigurationSerializable
             }
         }
 
-		//TODO: behaviors
+        int index = 0;
+        this.behaviors = new BehaviorData[inEntity.getMind().getBehaviours().size()];
+
+        for (Behavior behavior : inEntity.getMind().getBehaviours()) {
+            this.behaviors[index] = new BehaviorData(behavior);
+            System.out.println(this.behaviors[index]);
+            index++;
+        }
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -97,7 +105,16 @@ public class EntityData implements ConfigurationSerializable
 
         data.put("desires", serializedDesires);
 
-		//TODO: behaviors and desires
+        Map<String, Object>[] behaviorData = new HashMap[this.behaviors.length];
+
+        int index = 0;
+        for (BehaviorData bData : this.behaviors) {
+            behaviorData[index] = bData.serialize();
+            index++;
+        }
+
+        data.put("behaviors", behaviorData);
+
 		return data;
 	}
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/EntityData.java
@@ -1,7 +1,12 @@
 package de.kumpelblase2.remoteentities.persistence;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import de.kumpelblase2.remoteentities.api.thinking.Desire;
+import org.bukkit.Bukkit;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import de.kumpelblase2.remoteentities.api.Nameable;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
@@ -32,7 +37,30 @@ public class EntityData implements ConfigurationSerializable
 		this.stationary = inEntity.isStationary();
 		this.pushable = inEntity.isPushable();
 		this.speed = inEntity.getSpeed();
-		//TODO: behaviors and desires
+
+        int totalDesires = inEntity.getMind().getActionDesires().size() + inEntity.getMind().getMovementDesires().size();
+        int endLength = 0;
+        this.desires = new DesireData[totalDesires];
+
+        if (inEntity.getMind().getActionDesires().size() > 0) {
+            List<Desire> actionDesires = inEntity.getMind().getActionDesires();
+
+            for (int actionDesireIndex = 0; actionDesireIndex < actionDesires.size(); actionDesireIndex++) {
+                Desire desire = actionDesires.get(actionDesireIndex);
+                this.desires[actionDesireIndex] = new DesireData(desire);
+                endLength++;
+            }
+        }
+
+        if (inEntity.getMind().getMovementDesires().size() > 0) {
+            List<Desire> movementDesires = inEntity.getMind().getMovementDesires();
+            for (int movementDesireIndex = 0; movementDesireIndex < movementDesires.size(); movementDesireIndex++) {
+                Desire desire = movementDesires.get(movementDesireIndex);
+                this.desires[movementDesireIndex + endLength] = new DesireData(desire);
+            }
+        }
+
+		//TODO: behaviors
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -45,6 +73,7 @@ public class EntityData implements ConfigurationSerializable
 		this.stationary = (Boolean)inData.get("stationary");
 		this.pushable = (Boolean)inData.get("pushable");
 		this.speed = ((Double)inData.get("speed")).floatValue();
+        //TODO: behaviors and desires
 	}
 
 	@Override
@@ -58,6 +87,14 @@ public class EntityData implements ConfigurationSerializable
 		data.put("stationary", this.stationary);
 		data.put("pushable", this.pushable);
 		data.put("speed", this.speed);
+
+        ArrayList<Map<String, Object>> serializedDesires = new ArrayList();
+        for (DesireData desireData: this.desires) {
+            serializedDesires.add(desireData.serialize());
+        }
+
+        data.put("desires", serializedDesires);
+
 		//TODO: behaviors and desires
 		return data;
 	}

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/IEntitySerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/IEntitySerializer.java
@@ -1,6 +1,7 @@
 package de.kumpelblase2.remoteentities.persistence;
 
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
+import de.kumpelblase2.remoteentities.api.thinking.Desire;
 
 public interface IEntitySerializer
 {
@@ -11,4 +12,6 @@ public interface IEntitySerializer
 	public EntityData[] loadData();
 	
 	public RemoteEntity create(EntityData inData);
+
+    public Desire create(DesireData inData);
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/IEntitySerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/IEntitySerializer.java
@@ -13,5 +13,5 @@ public interface IEntitySerializer
 	
 	public RemoteEntity create(EntityData inData);
 
-    public Desire create(DesireData inData);
+    public Desire createDesireForEntity(DesireData inData, RemoteEntity entity);
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/IEntitySerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/IEntitySerializer.java
@@ -1,6 +1,7 @@
 package de.kumpelblase2.remoteentities.persistence;
 
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
+import de.kumpelblase2.remoteentities.api.thinking.Behavior;
 import de.kumpelblase2.remoteentities.api.thinking.Desire;
 
 public interface IEntitySerializer
@@ -8,10 +9,12 @@ public interface IEntitySerializer
 	public EntityData prepare(RemoteEntity inEntity);
 	
 	public boolean save(EntityData[] inData);
-	
+
 	public EntityData[] loadData();
 	
 	public RemoteEntity create(EntityData inData);
 
     public Desire createDesireForEntity(DesireData inData, RemoteEntity entity);
+
+    public Behavior createBehaviorForEntity(BehaviorData inData, RemoteEntity entity);
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
@@ -2,6 +2,8 @@ package de.kumpelblase2.remoteentities.persistence;
 
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
+import org.bukkit.plugin.Plugin;
+import sun.tools.tree.ThisExpression;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
@@ -38,6 +40,9 @@ public class ParameterData implements ConfigurationSerializable {
             this.type = "class";
             this.value = classes[0].getCanonicalName();
             this.requirement = classes[1].getCanonicalName();
+        } else if (object instanceof Plugin) {
+            this.type = "predefined_reference";
+            this.value = "plugin";
         }
     }
 
@@ -80,6 +85,9 @@ public class ParameterData implements ConfigurationSerializable {
             if (this.value.equals("entity")) {
                 replacementType = RemoteEntity.class.getCanonicalName();
                 replacementValue = entity;
+            } else if (this.value.equals("plugin")) {
+                replacementType = Plugin.class.getCanonicalName();
+                replacementValue = entity.getManager().getPlugin();
             }
         } else if (this.type.equals("class")) {
             replacementType = (String)this.requirement;

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
@@ -29,9 +29,6 @@ public class ParameterData implements ConfigurationSerializable {
         this.type = object.getClass().getCanonicalName();
         this.value = object;
 
-        System.out.println(this.type);
-        System.out.println(this.value);
-
         if (object instanceof RemoteEntity) {
             this.type = "predefined_reference";
             this.value = "entity";

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
@@ -17,7 +17,8 @@ public class ParameterData implements ConfigurationSerializable {
 
     public ParameterData(Object type, Object value)
     {
-
+        this.type = type;
+        this.value = value;
     }
 
     public ParameterData(Object object) {
@@ -27,13 +28,7 @@ public class ParameterData implements ConfigurationSerializable {
         if (object instanceof RemoteEntity) {
             this.type = "predefined_reference";
             this.value = "entity";
-        } else if (object instanceof Class) {
-            Class castedClass = (Class)object;
-            this.type = "class";
-            this.value = castedClass.getCanonicalName();
         }
-
-
     }
 
     public ParameterData(Map<String, Object> inData)
@@ -59,11 +54,9 @@ public class ParameterData implements ConfigurationSerializable {
 
         if (this.type.equals("predefined_reference")) {
             if (this.value.equals("entity")) {
-                replacementType = entity.getClass().getCanonicalName();
+                replacementType = RemoteEntity.class.getCanonicalName();
                 replacementValue = entity;
             }
-        } else if (this.type.equals("class")) {
-//            replacementType = Cl
         }
 
         if (replacementType == null) {

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/ParameterData.java
@@ -1,0 +1,88 @@
+package de.kumpelblase2.remoteentities.persistence;
+
+import de.kumpelblase2.remoteentities.api.RemoteEntity;
+import org.bukkit.configuration.serialization.ConfigurationSerializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ParameterData implements ConfigurationSerializable {
+    public Object type;
+    public Object value;
+
+    public ParameterData()
+    {
+
+    }
+
+    public ParameterData(Object type, Object value)
+    {
+
+    }
+
+    public ParameterData(Object object) {
+        this.type = object.getClass().getCanonicalName();
+        this.value = object;
+
+        if (object instanceof RemoteEntity) {
+            this.type = "predefined_reference";
+            this.value = "entity";
+        } else if (object instanceof Class) {
+            Class castedClass = (Class)object;
+            this.type = "class";
+            this.value = castedClass.getCanonicalName();
+        }
+
+
+    }
+
+    public ParameterData(Map<String, Object> inData)
+    {
+        this.type = inData.get("type");
+        this.value = inData.get("value");
+    }
+
+    @Override
+    public Map<String, Object> serialize() {
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("type", this.type);
+        data.put("value", this.value);
+
+        return data;
+    }
+
+    public ParameterData getSynthesizedParameterDataForEntity(RemoteEntity entity)
+    {
+        ParameterData returnData = null;
+        String replacementType = null;
+        Object replacementValue = null;
+
+        if (this.type.equals("predefined_reference")) {
+            if (this.value.equals("entity")) {
+                replacementType = entity.getClass().getCanonicalName();
+                replacementValue = entity;
+            }
+        } else if (this.type.equals("class")) {
+//            replacementType = Cl
+        }
+
+        if (replacementType == null) {
+            replacementType = (String)this.type;
+        }
+
+        if (replacementValue == null) {
+            replacementValue = this.value;
+        }
+
+        try {
+            returnData = new ParameterData(Class.forName(replacementType), replacementValue);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+
+
+
+        return returnData;
+    }
+}

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
@@ -93,7 +93,6 @@ public abstract class PreparationSerializer implements IEntitySerializer
             Class behaviorClass = Class.forName(inData.canonicallyWrittenClass);
 
             ParameterData parameterData[] = ConstructorSerializer.constructionalsFromArrayForEntity(inData.parameterData, entity);
-            System.out.println("Parameter info" + parameterData[0].value.getClass());
             Constructor constructor = behaviorClass.getConstructor(ParameterData[].class);
             return (Behavior)constructor.newInstance((Object)parameterData);
         } catch (ClassNotFoundException e) {

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
@@ -50,35 +50,22 @@ public abstract class PreparationSerializer implements IEntitySerializer
         } catch (ClassNotFoundException e) {
             e.printStackTrace();
         }
-        System.out.println("Logging 0");
 
         EntityManager manager = RemoteEntities.getManagerOfPlugin(this.m_plugin.getName());
-        Object[] constructors = new Object[inData.constructionData.length];
+        Object[] parameters = new Object[inData.constructionData.length];
         int index = 0;
 
-        System.out.println("Logging 1");
-        ParameterData constructionals[] = ConstructorSerializer.constructionalsFromArrayForEntity(inData.constructionData, entity);
+        ParameterData parameterData[] = ConstructorSerializer.constructionalsFromArrayForEntity(inData.constructionData, entity);
 
-        Class[] classCorrespondence = new Class[constructionals.length];
+        Class[] classCorrespondence = new Class[parameterData.length];
 
-        System.out.println("Logging 2");
-
-        for (ParameterData parameterData : constructionals) {
-             classCorrespondence[index] = (Class)constructionals[index].type;
-
+        for (ParameterData pData : parameterData) {
+            classCorrespondence[index] = (Class)pData.type;
+            parameters[index] = pData.value;
             index++;
         }
 
-        System.out.println("Logging 3");
-
-        Constructor[] constructors1 = DesireLookAtNearest.class.getConstructors();
-
-        System.out.println("Logging");
-        System.out.println(constructors1);
-        for (Constructor construct : constructors1) {
-            System.out.println(construct);
-            System.out.println(construct.getGenericParameterTypes());
-        }
+        System.out.println(DesireLookAtNearest.class.getConstructors()[1].getGenericParameterTypes());
 
         Constructor desireConstructor = null;
         try {
@@ -88,7 +75,7 @@ public abstract class PreparationSerializer implements IEntitySerializer
         }
 
         try {
-            return (Desire)desireConstructor.newInstance(constructors);
+            return (Desire)desireConstructor.newInstance(parameters);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
@@ -2,6 +2,8 @@ package de.kumpelblase2.remoteentities.persistence;
 
 import de.kumpelblase2.remoteentities.api.thinking.Desire;
 import de.kumpelblase2.remoteentities.api.thinking.goals.DesireLookAtNearest;
+import net.minecraft.server.v1_4_R1.EntityHuman;
+import net.minecraft.server.v1_4_R1.EntityLiving;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import de.kumpelblase2.remoteentities.CreateEntityContext;
@@ -51,34 +53,24 @@ public abstract class PreparationSerializer implements IEntitySerializer
             e.printStackTrace();
         }
 
-        EntityManager manager = RemoteEntities.getManagerOfPlugin(this.m_plugin.getName());
-        Object[] parameters = new Object[inData.constructionData.length];
-        int index = 0;
-
         ParameterData parameterData[] = ConstructorSerializer.constructionalsFromArrayForEntity(inData.constructionData, entity);
+        Class[] classes = new Class[1];
+        classes[0] = ParameterData[].class;
 
-        Class[] classCorrespondence = new Class[parameterData.length];
-
-        for (ParameterData pData : parameterData) {
-            classCorrespondence[index] = (Class)pData.type;
-            parameters[index] = pData.value;
-            index++;
-        }
-
-        System.out.println(DesireLookAtNearest.class.getConstructors()[1].getGenericParameterTypes());
-
-        Constructor desireConstructor = null;
-        try {
-            desireConstructor = desireClass.getConstructor(classCorrespondence);
-        } catch (Exception e) {
-            e.printStackTrace();
+        if (desireClass.getCanonicalName().equals(DesireLookAtNearest.class.getCanonicalName())) {
+            for (ParameterData pdata : parameterData) {
+                System.out.println(pdata.value.getClass());
+            }
         }
 
         try {
-            return (Desire)desireConstructor.newInstance(parameters);
+            Constructor constructor = desireClass.getConstructor(classes);
+            return (Desire)constructor.newInstance((Object)parameterData);
         } catch (Exception e) {
+            System.out.println("Failed for: " + desireClass.getCanonicalName());
             e.printStackTrace();
         }
+
 
         return null;
     }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
@@ -1,8 +1,10 @@
 package de.kumpelblase2.remoteentities.persistence;
 
+import de.kumpelblase2.remoteentities.api.DespawnReason;
 import de.kumpelblase2.remoteentities.api.thinking.Behavior;
 import de.kumpelblase2.remoteentities.api.thinking.Desire;
 import de.kumpelblase2.remoteentities.api.thinking.goals.DesireLookAtNearest;
+import de.kumpelblase2.remoteentities.entities.RemotePlayer;
 import net.minecraft.server.v1_4_R1.EntityHuman;
 import net.minecraft.server.v1_4_R1.EntityLiving;
 import org.bukkit.Bukkit;
@@ -35,7 +37,11 @@ public abstract class PreparationSerializer implements IEntitySerializer
 	public RemoteEntity create(EntityData inData)
 	{
 		EntityManager manager = RemoteEntities.getManagerOfPlugin(this.m_plugin.getName());
+
 		CreateEntityContext contex = manager.prepareEntity(inData.type);
+
+
+
 		contex.withName(inData.name).atLocation(inData.location.toBukkitLocation()).asPushable(inData.pushable).asStationary(inData.stationary).withID(inData.id);
 		contex.withSpeed(inData.speed);
 
@@ -51,10 +57,10 @@ public abstract class PreparationSerializer implements IEntitySerializer
 //        contex.withBehaviors(behaviors);
 
         RemoteEntity entity = contex.create();
+
         for (BehaviorData behaviorData : inData.behaviors) {
             entity.getMind().addBehaviour(this.createBehaviorForEntity(behaviorData, entity));
         }
-
 
 		return entity;
 	}

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
@@ -39,10 +39,22 @@ public abstract class PreparationSerializer implements IEntitySerializer
 		contex.withName(inData.name).atLocation(inData.location.toBukkitLocation()).asPushable(inData.pushable).asStationary(inData.stationary).withID(inData.id);
 		contex.withSpeed(inData.speed);
 
+//        Behavior[] behaviors = new Behavior[inData.behaviors.length];
+//
+//        int index = 0;
+//        for (BehaviorData behaviorData : inData.behaviors) {
+//            behaviors[index] = this.createBehaviorForEntity(behaviorData, entity);
+//
+//            index++;
+//        }
+//
+//        contex.withBehaviors(behaviors);
+
         RemoteEntity entity = contex.create();
         for (BehaviorData behaviorData : inData.behaviors) {
             entity.getMind().addBehaviour(this.createBehaviorForEntity(behaviorData, entity));
         }
+
 
 		return entity;
 	}

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
@@ -1,10 +1,14 @@
 package de.kumpelblase2.remoteentities.persistence;
 
+import de.kumpelblase2.remoteentities.api.thinking.Desire;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import de.kumpelblase2.remoteentities.CreateEntityContext;
 import de.kumpelblase2.remoteentities.EntityManager;
 import de.kumpelblase2.remoteentities.RemoteEntities;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
+
+import java.lang.reflect.Constructor;
 
 public abstract class PreparationSerializer implements IEntitySerializer
 {
@@ -28,6 +32,70 @@ public abstract class PreparationSerializer implements IEntitySerializer
 		CreateEntityContext contex = manager.prepareEntity(inData.type);
 		contex.withName(inData.name).atLocation(inData.location.toBukkitLocation()).asPushable(inData.pushable).asStationary(inData.stationary).withID(inData.id);
 		contex.withSpeed(inData.speed);
+
+//        for (DesireData)
+
 		return contex.create();
 	}
+
+    @Override
+    public Desire create(DesireData inData)
+    {
+        Class desireClass = null;
+        try {
+            desireClass = Class.forName(inData.name);
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        EntityManager manager = RemoteEntities.getManagerOfPlugin(this.m_plugin.getName());
+        Object[] constructors = new Object[inData.constructionData.length];
+        int index = 0;
+
+        for (Object object : inData.constructionData) {
+            Object result = object;
+
+            if (object instanceof String) {
+                String string = (String)object;
+                String entityKeyword = "EntityID = ";
+                if (string.startsWith(entityKeyword)) {
+                    int id = Integer.parseInt(string.substring(entityKeyword.length()));
+                    RemoteEntity entity = manager.getRemoteEntityByID(id);
+                    System.out.println(entity);
+                    result = entity;
+                }
+
+            }
+
+            constructors[index] = result;
+            index++;
+        }
+
+        Class[] classCorrespondence = new Class[constructors.length];
+        index = 0;
+
+        for (Object object : constructors) {
+            if (object instanceof RemoteEntity)
+                classCorrespondence[index] = RemoteEntity.class;
+            else
+                classCorrespondence[index] = object.getClass();
+
+            index++;
+        }
+
+        Constructor desireConstructor = null;
+        try {
+            desireConstructor = desireClass.getConstructor(classCorrespondence);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        try {
+            return (Desire)desireConstructor.newInstance(constructors);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/PreparationSerializer.java
@@ -1,6 +1,7 @@
 package de.kumpelblase2.remoteentities.persistence;
 
 import de.kumpelblase2.remoteentities.api.thinking.Desire;
+import de.kumpelblase2.remoteentities.api.thinking.goals.DesireLookAtNearest;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import de.kumpelblase2.remoteentities.CreateEntityContext;
@@ -9,6 +10,7 @@ import de.kumpelblase2.remoteentities.RemoteEntities;
 import de.kumpelblase2.remoteentities.api.RemoteEntity;
 
 import java.lang.reflect.Constructor;
+import java.util.HashMap;
 
 public abstract class PreparationSerializer implements IEntitySerializer
 {
@@ -39,48 +41,43 @@ public abstract class PreparationSerializer implements IEntitySerializer
 	}
 
     @Override
-    public Desire create(DesireData inData)
+    public Desire createDesireForEntity(DesireData inData, RemoteEntity entity)
     {
         Class desireClass = null;
+
         try {
             desireClass = Class.forName(inData.name);
         } catch (ClassNotFoundException e) {
             e.printStackTrace();
         }
+        System.out.println("Logging 0");
 
         EntityManager manager = RemoteEntities.getManagerOfPlugin(this.m_plugin.getName());
         Object[] constructors = new Object[inData.constructionData.length];
         int index = 0;
 
-        for (Object object : inData.constructionData) {
-            Object result = object;
+        System.out.println("Logging 1");
+        ParameterData constructionals[] = ConstructorSerializer.constructionalsFromArrayForEntity(inData.constructionData, entity);
 
-            if (object instanceof String) {
-                String string = (String)object;
-                String entityKeyword = "EntityID = ";
-                if (string.startsWith(entityKeyword)) {
-                    int id = Integer.parseInt(string.substring(entityKeyword.length()));
-                    RemoteEntity entity = manager.getRemoteEntityByID(id);
-                    System.out.println(entity);
-                    result = entity;
-                }
+        Class[] classCorrespondence = new Class[constructionals.length];
 
-            }
+        System.out.println("Logging 2");
 
-            constructors[index] = result;
+        for (ParameterData parameterData : constructionals) {
+             classCorrespondence[index] = (Class)constructionals[index].type;
+
             index++;
         }
 
-        Class[] classCorrespondence = new Class[constructors.length];
-        index = 0;
+        System.out.println("Logging 3");
 
-        for (Object object : constructors) {
-            if (object instanceof RemoteEntity)
-                classCorrespondence[index] = RemoteEntity.class;
-            else
-                classCorrespondence[index] = object.getClass();
+        Constructor[] constructors1 = DesireLookAtNearest.class.getConstructors();
 
-            index++;
+        System.out.println("Logging");
+        System.out.println(constructors1);
+        for (Constructor construct : constructors1) {
+            System.out.println(construct);
+            System.out.println(construct.getGenericParameterTypes());
         }
 
         Constructor desireConstructor = null;

--- a/src/main/java/de/kumpelblase2/remoteentities/persistence/serializers/JSONSerializer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/persistence/serializers/JSONSerializer.java
@@ -28,7 +28,7 @@ public class JSONSerializer extends PreparationSerializer
 	@Override
 	public boolean save(EntityData[] inData)
 	{
-		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
 		String json = gson.toJson(inData);
 		return this.writeToFile(json);
 	}


### PR DESCRIPTION
Will try to submit my updates every night, since we're on opposite time zones. This adds the entities to the world (though they duplicate, will need to remove all on disable or something.) Also creates desires in JSON, though priority is unimplemented and it does not reassemble them from string class construction.

Example:

``` json
"desires": [
      {
        "desireName": "DesireSwim",
        "priority": 0,
        "type": 4
      },
      {
        "desireName": "DesireLookRandomly",
        "priority": 0,
        "type": 3
      },
      {
        "desireName": "DesireLookAtNearest",
        "priority": 0,
        "type": 0
      }
```
