### PR TITLE
DesireMoveToLocation shouldExecute

### DIFF
--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireMoveToLocation.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireMoveToLocation.java
@@ -22,7 +22,7 @@ public class DesireMoveToLocation extends DesireBase implements OneTimeDesire
 	@Override
 	public boolean shouldExecute()
 	{
-		return this.getRemoteEntity().getBukkitEntity().getLocation().distanceSquared(this.m_targetLocation) > 1.15;
+		return !((CraftLivingEntity)this.getRemoteEntity().getBukkitEntity()).getHandle().getNavigation().f();
 	}
 	
 	@Override


### PR DESCRIPTION
The distanceSquared can sometimes be greater then 1.15 so using the minecraft navigation f() method fixes this issue.
