### PR TITLE
fakeDamage() method for the RemotePlayer entity.

### DIFF
--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
@@ -115,7 +115,6 @@ public class RemotePlayer extends RemoteAttackingBaseEntity<Player>
 		((WorldServer)this.getHandle().world).getTracker().a(this.getHandle(), new Packet18ArmAnimation(this.getHandle(), 1));
 	}
 	
-
 	/**
      * Send the hurt animation to nearby players.
      */

--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
@@ -114,6 +114,15 @@ public class RemotePlayer extends RemoteAttackingBaseEntity<Player>
 	{
 		((WorldServer)this.getHandle().world).getTracker().a(this.getHandle(), new Packet18ArmAnimation(this.getHandle(), 1));
 	}
+	
+
+	/**
+     * Send the hurt animation to nearby players.
+     */
+	public void fakeDamage()
+	{
+		((WorldServer)this.getHandle().world).getTracker().a(this.getHandle(), new Packet18ArmAnimation(this.getHandle(), 2));
+	}
 
 	@Override
 	protected void setupSounds()


### PR DESCRIPTION
I added a fakeDamage() method to the RemotePlayer entity, this makes it possible to, obviously, make the playerentity appear being damaged. 
