### PR TITLE
Fixes EntityManager returning incorrect RemoteEntity

### DIFF
--- a/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/EntityManager.java
@@ -308,19 +308,13 @@ public class EntityManager
 		if(!this.isRemoteEntity(inEntity))
 			return null;
 
-		if(inEntity.hasMetadata("remoteentity"))
-		{
-			for(MetadataValue value : inEntity.getMetadata("remoteentity"))
-			{
-				if(value.getOwningPlugin() == this.m_plugin)
-				{
-					if(!(value.value() instanceof RemoteEntity))
-						continue;
-
-					return (RemoteEntity)value.value();
-				}
-			}
-		}
+        for (RemoteEntity remoteEntity : this.getAllEntities())
+        {
+            if (remoteEntity.getBukkitEntity() == inEntity)
+            {
+                return remoteEntity;
+            }
+        }
 
 		EntityLiving entityHandle = ((CraftLivingEntity)inEntity).getHandle();
 		return ((RemoteEntityHandle)entityHandle).getRemoteEntity();


### PR DESCRIPTION
Both @Coestar and @king601 can vouch for this occurring:

When passing this method two distinct LivingEntity's (of the same name, for instance "test" and "test"), this method would return the same RemoteEntity.

This caused adverse behavior, such as one entity getting punched, a fake damage being dispatched, and the wrong RemoteEntity faking the damage (or whatever the action done was.)

In my testing, this worked :100: percent of the time and fixed everything. :sparkles: 
