### PR TITLE
Fix Name-Changes Clearing Behaviors

### DIFF
--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemoteBaseEntity.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemoteBaseEntity.java
@@ -324,7 +324,7 @@ public abstract class RemoteBaseEntity<T extends LivingEntity> implements Remote
 		if(event.isCancelled() && inReason != DespawnReason.PLUGIN_DISABLE)
 			return false;
 
-		if(inReason != DespawnReason.CHUNK_UNLOAD)
+		if(inReason != DespawnReason.CHUNK_UNLOAD && inReason != DespawnReason.NAME_CHANGE)
 		{
 			for(Behavior behaviour : this.getMind().getBehaviours())
 			{


### PR DESCRIPTION
Similar to chunk unloads, name changes should be exempted from the cleanup that `RemoteBaseEntity` does.

:white_check_mark: ​ **Fixed**
- Entities having their names changed losing their behaviors and desires.

:warning:  ​  **Note:**
Any behaviors or desires which require access to the Bukkit entity may be broken if not manually notified by the original plugin. As an example, a behavior which sets attributes on the Bukkit entity will not know to set them again, as the entity has been changed out from under it. Consequently, it may be wise to add something along the lines of an `onLivingEntityChange()`, to allow the object to react to and handle the change.
