### PR TITLE
Player Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/entities/RemotePlayer.java
@@ -86,7 +86,9 @@ public class RemotePlayer extends RemoteAttackingBaseEntity<Player>
 	public void setSpeed(double inSpeed)
 	{
 		super.setSpeed(inSpeed);
-		((EntityPlayer)this.m_entity).abilities.walkSpeed = (float)inSpeed;
+
+		if(this.m_entity != null)
+			((EntityPlayer)this.m_entity).abilities.walkSpeed = (float)inSpeed;
 	}
 
 	@Override

--- a/src/main/java/de/kumpelblase2/remoteentities/nms/RemoteEntityNetworkManager.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/nms/RemoteEntityNetworkManager.java
@@ -13,12 +13,12 @@ public class RemoteEntityNetworkManager extends NetworkManager
 	public RemoteEntityNetworkManager(MinecraftServer server) throws IOException
 	{
 		super(false);
+
+		this.assignReplacementNetworking();
 	}
 
-	@Override
-	public void channelActive(ChannelHandlerContext inContext) throws Exception
+	private void assignReplacementNetworking()
 	{
-		super.channelActive(inContext);
 		ReflectionUtil.setNetworkChannel(this, new NullChannel(null));
 		ReflectionUtil.setNetworkAddress(this, new SocketAddress(){});
 	}


### PR DESCRIPTION
Several fixes which restore functionality and add compatibility with 1.7.2.

:white_check_mark: ​ **Fixed**
- Commons-Lang reference not working (Bukkit references 2.3, we require 3.1. Exceptions are thrown when attempting to use Bukkit's.)
- Fix NPE when setting speed (seen during restoration from persistence/disk.)
- Fix replacement networking code not being assigned before Bukkit calls, leading to an NPE. (#74)

:100: Tested working on CraftBukkit 1.7.2-R0.1 (Build #02943) with creation and persistence.
