### PR TITLE
Fixes random jumping and version checking

### DIFF
--- a/src/main/java/de/kumpelblase2/remoteentities/RemoteEntities.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/RemoteEntities.java
@@ -111,7 +111,7 @@ public class RemoteEntities extends JavaPlugin
 	void checkConfig()
 	{
 		this.getConfig().set("autoUpdateSources", this.getConfig().get("autoUpdateSources", false));
-		COMPATIBLE_REVISION = this.getConfig().getString("COMPATIBLE_REVISION", "1_7_R1");
+		COMPATIBLE_REVISION = this.getConfig().getString("COMPATIBLE_REVISION", "v1_7_R2");
 		COMPATIBLE_VERSION = this.getConfig().getString("COMPATIBLE_VERSION", "1.7.2");
 		this.saveConfig();
 	}

--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireSwim.java
@@ -34,7 +34,7 @@ public class DesireSwim extends DesireBase
 	@Override
 	public boolean shouldExecute()
 	{
-		return this.getEntityHandle() != null && (this.getEntityHandle().L() || this.getEntityHandle().Q());
+		return this.getEntityHandle() != null && this.getEntityHandle().M();
 	}
 
 	@Override


### PR DESCRIPTION
Fixed the random mob jumping (caused by the swim desires) and also the version checking which now allows the plugin to be run on a 1.7.5 server.

This should hopefully fix #71 and help towards #80.
