### PR TITLE
Fixed null pointer exception in DesireFollowParent

### DIFF
--- a/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireFollowParent.java
+++ b/src/main/java/de/kumpelblase2/remoteentities/api/thinking/goals/DesireFollowParent.java
@@ -97,7 +97,9 @@ public class DesireFollowParent extends DesireBase
 	@Override
 	public boolean canContinue()
 	{
-		if(!this.m_parent.isAlive())
+		if(this.m_parent == null)
+			return false;
+		else if(!this.m_parent.isAlive())
 			return false;
 		else
 		{


### PR DESCRIPTION
Fixed a NullPointerException caused by not having a parent entity set in the DesireFollowParent goal.
